### PR TITLE
Fix - Product DTO

### DIFF
--- a/tracker/tracker_data/src/main/java/com/plcoding/tracker/tracker_data/remote/dto/Product.kt
+++ b/tracker/tracker_data/src/main/java/com/plcoding/tracker/tracker_data/remote/dto/Product.kt
@@ -3,7 +3,7 @@ package com.plcoding.tracker.tracker_data.remote.dto
 import com.squareup.moshi.Json
 
 data class Product(
-    @field:Json(name = "image_fromt_thumb_url")
+    @field:Json(name = "image_front_thumb_url")
     val imageFrontThumbUrl: String?,
     val nutriments: Nutriments,
     @field:Json(name = "product_name")


### PR DESCRIPTION
### As IS
TrackableFood, TrackedFood images were not displayed correctly due to incorrect property names in Product DTO.

### To Be
Now the images are displayed correctly.